### PR TITLE
Cleanup proofs:

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -28,7 +28,7 @@ lemma sp1_addOperation
       ( V04.val + 256 * V05.val + 65536 * V06.val + 16777216 * V07.val ) ) % 4294967296 =
     ( V08.val + 256 * V09.val + 65536 * V10.val + 16777216 * V11.val )
      := by
-  simp [@sub_eq_zero BabyBear _ _ 1, mul_eq_zero] at *
+  simp [sub_eq_zero (b := (1 : BabyBear))] at *
   rcases C11 <;> rcases C12 <;> rcases C13 <;> subst_eqs <;>
   simp [BabyBearPrime, Fin.add_def, Fin.sub_def] at * <;>
   omega

--- a/Sp1Poc/Basic.lean
+++ b/Sp1Poc/Basic.lean
@@ -1,18 +1,13 @@
 import Mathlib
 
 abbrev BabyBearPrime : ℕ := 2013265921
-
-@[simp]
-axiom BabyBearPrimeIsPrime : Nat.Prime BabyBearPrime
+lemma prime_BabyBearPrime : Nat.Prime BabyBearPrime := by norm_num
 
 abbrev BabyBear : Type := Fin BabyBearPrime
+
 instance : NeZero BabyBearPrime := by constructor; decide
 
 instance : NoZeroDivisors BabyBear := by
-  constructor; intros a b Heq; rw [Fin.mul_def] at Heq; by_contra Hneq; simp at *
-  rw [@Fin.mk_eq_zero _ a] at Hneq; rw [@Fin.mk_eq_zero _ b] at Hneq
-  have Hncp_ab : ¬ Nat.Coprime BabyBearPrime (a.1 * b.1) := by
-    rw [← Nat.Prime.dvd_iff_not_coprime BabyBearPrimeIsPrime]; omega
-  apply Hncp_ab
-  apply Nat.Coprime.mul_right <;> apply Nat.coprime_of_lt_prime <;>
-  (try omega) <;> simp
+  have : IsDomain (ZMod BabyBearPrime) := ZMod.instIsDomain (hp := ⟨prime_BabyBearPrime⟩)
+  simp [ZMod] at this
+  infer_instance


### PR DESCRIPTION
- show primality explicitly (mostly as 'documentation')
- simplify the proof it has no zero divisors
- simplify the main proof