### PR TITLE
Very minor cleanups.

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -1,4 +1,4 @@
-import Sp1Poc
+import Sp1Poc.Cli
 import Lake
 import Lean
 

--- a/Sp1Poc.lean
+++ b/Sp1Poc.lean
@@ -2,5 +2,6 @@
 -- Import modules here that should be built as part of the library.
 import Sp1Poc.Basic
 import Sp1Poc.Cli
+import Sp1Poc.Specs
 import Sp1Poc.Templater
 import Sp1Poc.Wheels

--- a/Sp1Poc/Templater.lean
+++ b/Sp1Poc/Templater.lean
@@ -57,7 +57,7 @@ private def translateConstraint (c : TSyntax `constraint) : Except String (Strin
       | 9 => let ⟨[_, _, _, _, _]⟩ := terms.getElems | throw "Impossible."
              throw s!"Unsupported lookup: MSB"
       -- 3 parameters: U16Range
-      | 5 => let ⟨[_, _, b]⟩ := terms.getElems | throw "Impossible."
+      | 5 => let ⟨[_, _, _]⟩ := terms.getElems | throw "Impossible."
              throw s!"Unsupported lookup: U16Range"
       -- Incorrect number of parameters
       | _ => throw s!"Incorrect number of parameters provided to Byte-related lookup"


### PR DESCRIPTION
I assume `let [_, _, _] := t | throw A; throw B` is written like this on purpose to have this shape deconstructed 'for the future'.
If that's not the intent, then `if t.size != 3 then throw A; throw B` is a better way to do this.